### PR TITLE
Improve German translation for Stats in EmbedLanguageMappings.json

### DIFF
--- a/SysBot.Pokemon/SV/BotRaid/Language/EmbedLanguageMappings.json
+++ b/SysBot.Pokemon/SV/BotRaid/Language/EmbedLanguageMappings.json
@@ -4,7 +4,7 @@
         "ja": "ステータス",
         "fr": "Statistiques",
         "es": "Estadísticas",
-        "de": "Status",
+        "de": "Werte",
         "it": "Statistiche",
         "ko": "스탯",
         "zh-Hans": "数据",


### PR DESCRIPTION
This PR improves the accuracy of the German translation in the embed language mappings.

## Change made:
- **Stats**: Changed from "Status" to "Werte" for better accuracy

## Reason:
- "Status" in German means "state" or "condition" 
- "Werte" means "values" or "stats" which is more appropriate for Pokemon statistics
- This makes the German translation more accurate and consistent with Pokemon terminology

## Files changed:
- `SysBot.Pokemon/SV/BotRaid/Language/EmbedLanguageMappings.json`

The change improves the user experience for German-speaking users by using the correct terminology.