### PR TITLE
Improve German translation: Fix grammatical error "Schillernd" → "Schillerndes"

### DIFF
--- a/SysBot.Pokemon/SV/BotRaid/Language/EmbedLanguageMappings.json
+++ b/SysBot.Pokemon/SV/BotRaid/Language/EmbedLanguageMappings.json
@@ -325,7 +325,7 @@
         "ja": "色違い",
         "fr": "Chromatique",
         "es": "Variocolor",
-        "de": "Schillernd",
+        "de": "Schillerndes",
         "it": "Cromatico",
         "ko": "색이 다른",
         "zh-Hans": "闪光",


### PR DESCRIPTION
## Changes
Fixed grammatical error in German translation for shiny Pokemon names.

**Before:** `Schillernd [Pokemon]` (grammatically incorrect)  
**After:** `Schillerndes [Pokemon]` (correct German adjective declension)

## Reason
German adjectives must be properly declined. "Schillerndes" is the correct form when used as an attributive adjective before a Pokemon name.

This improves the user experience for German players by providing grammatically correct text.