### PR TITLE
Starting from splash screen, and a null issue correction

### DIFF
--- a/SysBot.Pokemon/SV/BotRaid/RotatingRaidBotSV.cs
+++ b/SysBot.Pokemon/SV/BotRaid/RotatingRaidBotSV.cs
@@ -3703,6 +3703,13 @@ ALwkMx63fBR0pKs+jJ8DcFrcJR50aVv1jfIAQpPIK5G6Dk/4hmV12Hdu5sSGLl40
                     // Back out for next attempt if needed
                     if (attemptCount < maxAttempts && !connected)
                         await Click(B, 0_500, token).ConfigureAwait(false);
+                    
+                    // If attemptCount 1 fails, press A to try to get past the splash screen. If this is set to 2 it will connect just in time on attempt 5 (Tested implementation, 1 works the best) 
+                    if (attemptCount == 1)
+                    {
+                        Log("Pressing A in case our switch is at the splash screen, and not in overworld.");
+                        await Click(A, 0_500, token).ConfigureAwait(false); // Press A to try to get past the splash screen
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/SysBot.Pokemon/SV/BotRaid/RotatingRaidBotSV.cs
+++ b/SysBot.Pokemon/SV/BotRaid/RotatingRaidBotSV.cs
@@ -3662,7 +3662,9 @@ ALwkMx63fBR0pKs+jJ8DcFrcJR50aVv1jfIAQpPIK5G6Dk/4hmV12Hdu5sSGLl40
                             Color = Color.Red,
                             ThumbnailUrl = "https://raw.githubusercontent.com/bdawg1989/sprites/main/imgs/x.png"
                         };
-                        _ = await EchoUtil.RaidEmbed(null, "", embed);
+                        
+                        //You should remove the await keyword since EchoUtil.RaidEmbed returns void, and replace null with an empty byte array to satisfy the non-nullable parameter.
+                        EchoUtil.RaidEmbed([], "", embed);
 
                         await Click(B, 0_500, token).ConfigureAwait(false);
                         await Click(B, 0_500, token).ConfigureAwait(false);


### PR DESCRIPTION
[19:00:30] - Xieon-: Two attempts to connect have failed - Pressing A in case our switch is at the splash screen, and not in overworld.
[19:00:30] - Xieon    Attempt 2 of 5: Trying to connect online...
[19:00:43] - Xieon    Rechecking the online connection status...
[19:00:44] - Xieon    Attempt 3 of 5: Trying to connect online...
[19:00:57] - Xieon    Rechecking the online connection status...
[19:00:58] - Xieon    Attempt 4 of 5: Trying to connect online...
[19:01:11] - Xieon    Rechecking the online connection status...
[19:01:11] - Xieon    Connection established successfully.
